### PR TITLE
Fix NullPointerException when wifi state changes

### DIFF
--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/utils/connection/WifiConnectionHandler.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/utils/connection/WifiConnectionHandler.java
@@ -99,7 +99,7 @@ public class WifiConnectionHandler {
 
                     switch (networkState) {
                         case CONNECTED:
-                            final WifiInfo wifiInfo = intent.getParcelableExtra(WifiManager.EXTRA_WIFI_INFO);
+                            final WifiInfo wifiInfo = wifiMgr.getConnectionInfo();
                             final String wifiSSID = wifiInfo.getSSID();
                             Timber.i("Connected to " + wifiSSID);
 


### PR DESCRIPTION
EXTRA_WIFI_INFO has been deprecated on Android Api 28.
Therefore, get connection info from wifi manager